### PR TITLE
ci: add auto-assigner workflow for pull requests

### DIFF
--- a/.github/workflows/autoassigner_workflow.yml
+++ b/.github/workflows/autoassigner_workflow.yml
@@ -1,0 +1,13 @@
+name: Auto Assigner
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.1.1


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow named "Auto Assigner".

This workflow will automatically assign the author of a pull request as an assignee. It triggers on any `pull_request` event.

The workflow uses the `toshimaru/auto-author-assign@v2.1.1` action to perform the assignment.